### PR TITLE
Mark a failed build as failed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,3 +46,4 @@
     - name: Handling error
       debug:
         msg: "Please add '--extra-vars force_build=true' to force building"
+      failed_when: true


### PR DESCRIPTION
Jenks was marking failed builds as good, as the ansible error handler wasn't propogating the error