### PR TITLE
Move playbook default to packer template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,5 @@ packer_http_port: '8000-9000/tcp'
 
 convert_to_template: 'false'
 vm_boot_string: ''
-playbook_file: 'no-op.yml'
 inventory_directory: '/etc/ansible'
 # extra_vars: '' # unused

--- a/files/packer-template/variables.pkr.hcl
+++ b/files/packer-template/variables.pkr.hcl
@@ -109,6 +109,7 @@ variable "ssh_public_key" {
 
 variable "playbook_file" {
   type = string
+  default = "no-op.yml"
 }
 
 variable "inventory_directory" {


### PR DESCRIPTION
Packer needs a fallback provisioning script
Using ansible role defaults makes it very hard for the associated playbook to set the provisioning script
Easiest to move the default to the packer variable definitions